### PR TITLE
Fix loading of mounted secret files to env variables

### DIFF
--- a/lib/on_container/load_env_secrets.rb
+++ b/lib/on_container/load_env_secrets.rb
@@ -12,10 +12,10 @@ OnContainer::Secrets::GoogleCloud::EnvLoader.perform!
 
 # Process only a known list of env vars that can filled by reading a file (i.e.
 # a docker secret):
-Dir["#{ENV.fetch('SECRETS_PATH', '/run/secrets')}/*"].each do |secret_filepath|
-  next unless File.file?(secret_filepath)
-
-  secret_envvarname = File.basename(secret_filepath, '.*').upcase
+Dir["#{ENV.fetch('SECRETS_PATH', '/run/secrets')}/**/*"].map do |path|
+  Pathname.new(path)
+end.select(&:file?).each do |secret_filepath|
+  secret_envvarname = secret_filepath.basename('.*').to_s.upcase
 
   # Skip if variable is already set - already-set variables have precedence over
   # the secret files:

--- a/lib/on_container/load_env_secrets.rb
+++ b/lib/on_container/load_env_secrets.rb
@@ -12,7 +12,7 @@ OnContainer::Secrets::GoogleCloud::EnvLoader.perform!
 
 # Process only a known list of env vars that can filled by reading a file (i.e.
 # a docker secret):
-Dir["#{ENV.fetch('SECRETS_PATH', '/run/secrets/')}*"].each do |secret_filepath|
+Dir["#{ENV.fetch('SECRETS_PATH', '/run/secrets')}/*"].each do |secret_filepath|
   next unless File.file?(secret_filepath)
 
   secret_envvarname = File.basename(secret_filepath, '.*').upcase


### PR DESCRIPTION
Fixes loading of mounted secrets on kubernetes environments by:
* Not requiring `SECRETS_PATH` env variable (including the default value) to end in `/`
* Recurses over the `SECRETS_PATH` directory to find files inside sub-directories