### PR TITLE
Fix order of user and password variables crashing secret load

### DIFF
--- a/lib/on_container/secrets/url_variable_processor.rb
+++ b/lib/on_container/secrets/url_variable_processor.rb
@@ -55,7 +55,8 @@ module OnContainer
 
         uri = URI(ENV[url_key])
 
-        credential_keys.each do |credential_key|
+        # Reverse sorting will place "*_USER" before "*_PASS":
+        credential_keys.sort.reverse.each do |credential_key|
           credential_value = URI.encode_www_form_component ENV[credential_key]
           case credential_key
           when /USER/ then uri.user = credential_value

--- a/spec/secrets/url_variable_processor_spec.rb
+++ b/spec/secrets/url_variable_processor_spec.rb
@@ -60,6 +60,23 @@ RSpec.describe OnContainer::Secrets::UrlVariableProcessor, type: :env_spec do
           .from('https://example.com')
           .to 'https://example-user:example-pass@example.com'
       end
+
+      context 'with "*_PASS" processed before "*_USER" (is it possible?)' do
+        let :example_env_vars do
+          {
+            EXAMPLE_PASS: 'example-pass',
+            EXAMPLE_USER: 'example-user',
+            EXAMPLE_URL: 'https://example.com'
+          }
+        end
+
+        it 'adds the matching credentials to the "*_URL" env var' do
+          expect { subject.perform! }
+            .to change { ENV['EXAMPLE_URL'] }
+            .from('https://example.com')
+            .to 'https://example-user:example-pass@example.com'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
[Closes #17]

Ensures that the "*_USER" variables are processed before the "*_PASS" variables for "*_URL" environment variables