### PR TITLE
Allow skipping setup lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,17 @@
 PATH
   remote: .
   specs:
-    on_container (0.0.14)
+    on_container (0.0.16)
       activesupport (>= 4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3)
+    activesupport (7.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -21,7 +20,7 @@ GEM
     byebug (11.1.1)
     climate_control (0.2.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
     debase-ruby_core_source (0.10.12)
@@ -77,7 +76,7 @@ GEM
       google-protobuf (~> 3.11)
       googleapis-common-protos (>= 1.3.10, < 2.0)
       grpc (~> 1.27)
-    i18n (1.8.9)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     jwt (2.2.2)
@@ -89,7 +88,7 @@ GEM
     memoist (0.16.2)
     method_source (0.9.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nokogiri (1.11.1)
@@ -172,7 +171,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
     yard (0.9.26)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/lib/on_container/dev/setup_ops.rb
+++ b/lib/on_container/dev/setup_ops.rb
@@ -5,7 +5,7 @@ module OnContainer
     module SetupOps
       APP_PATH = File.expand_path '.'
       TRUEISH_VALUES = %w[true True TRUE yes Yes YES].freeze
-      SKIP_SETUP_ENV_VAR = 'ON_CONTAINER_SKIP_SETUP_LOCK'
+      SKIP_SETUP_ENV_VAR = 'ON_CONTAINER_SKIP_SETUP_LOCK'.freeze
 
       def app_temp_path
         "#{APP_PATH}/tmp"
@@ -44,7 +44,6 @@ module OnContainer
         end
 
         yield
-
       ensure
         unlock_setup
       end

--- a/lib/on_container/dev/setup_ops.rb
+++ b/lib/on_container/dev/setup_ops.rb
@@ -4,25 +4,37 @@ module OnContainer
   module Dev
     module SetupOps
       APP_PATH = File.expand_path '.'
-  
-      def app_temp_path; "#{APP_PATH}/tmp"; end
-      def app_setup_wait; ENV.fetch('APP_SETUP_WAIT', '5').to_i; end
-      def app_setup_lock_path; "#{app_temp_path}/setup.lock"; end
-  
+      TRUEISH_VALUES = %w[true True TRUE yes Yes YES].freeze
+      SKIP_SETUP_ENV_VAR = 'ON_CONTAINER_SKIP_SETUP_LOCK'
+
+      def app_temp_path
+        "#{APP_PATH}/tmp"
+      end
+
+      def app_setup_wait
+        ENV.fetch('APP_SETUP_WAIT', '5').to_i
+      end
+
+      def app_setup_lock_path
+        "#{app_temp_path}/setup.lock"
+      end
+
       def lock_setup
         system "mkdir -p #{app_temp_path} && touch #{app_setup_lock_path};"
       end
-      
+
       def unlock_setup
         system "rm -rf #{app_setup_lock_path}"
       end
-      
+
       def wait_setup
         puts 'Waiting for app setup to finish...'
         sleep app_setup_wait
       end
 
       def on_setup_lock_acquired
+        return yield if TRUEISH_VALUES.include? ENV[SKIP_SETUP_ENV_VAR]
+
         wait_setup while File.exist?(app_setup_lock_path)
 
         lock_setup
@@ -42,7 +54,7 @@ module OnContainer
           rails rspec sidekiq hutch puma rake webpack webpack-dev-server
         ].include?(ARGV[0])
       end
-      
+
       def command_might_require_database?
         %w[
           rails rspec sidekiq hutch puma rake


### PR DESCRIPTION
The "Setup lock" prevented parallel app containers from trying to run the container setup tasks concurrently. While this was common in our previous development setup with Docker - having a "tests" container as well as a "web" and "webpacker" containers simultaneously - this hasn't been the case when we switched to Visual Studio Code Devcontainers, where we just use a "development" container and that's it.

So, this PR adds code that skips creating the setup.lock file - and waiting for it to be removed - whenever the `ON_CONTAINER_SKIP_SETUP_LOCK` environment variable is present with a "true-ish" value, when running any (entrypoint) script that uses the `on_container` routines.